### PR TITLE
Fixed a bug in the blog section page titles not incorporating the h1 content

### DIFF
--- a/soupault.toml
+++ b/soupault.toml
@@ -145,6 +145,9 @@
 [widgets.set-page-title]
   widget = "title"
 
+  # Must run only after the header with an <h1 id="post-title"> element is inserted, which affects the blog section pages
+  after = 'make-post-header'
+
   selector = ["#page-title", "h1"]
   default = "Sample site"
   append = " &mdash; Sample site"


### PR DESCRIPTION
Hi,

Firstly, thanks for developing soupault. It's early days for me yet but it looks like it's pretty much what I'm after. Hopefully this PR isn't excessively verbose - it does far outweigh the size of the actual code change! However, the verbosity also helps me to understand the unfamiliar code base and make sure I've performed due diligence.

## Bug reproduction steps

1. Build and serve the build directory as normal.
2. Observe the page title for the first-post and second-post do not reflect the contents of the h1
   element but the home, about and tag pages do. This impacts the browser history, as previous blog pages will only show the generic 'Sample site' text.

    ```
    $ for slug in blog/first-post blog/second-post blog/tag/test blog/tag/post blog/tag/ blog about ; do  echo -e "\n$slug title and h1:" && curl -s "http://127.0.0.1:8000/$slug/" |grep -A2 -e '<h1' -e '<title>' ; done

    blog/first-post title and h1:
      <title>
       Sample site
      </title>
    --
        <h1 id="post-title">
         My first post
        </h1>

    blog/second-post title and h1:
      <title>
       Sample site
      </title>
    --
        <h1 id="post-title">
         My second post
        </h1>

    blog/tag/test title and h1:
      <title>
       Posts tagged "test" — Sample site
      </title>
    --
       <h1>
        Posts tagged "test"
       </h1>

    blog/tag/post title and h1:
      <title>
       Posts tagged "post" — Sample site
      </title>
    --
       <h1>
        Posts tagged "post"
       </h1>

    blog/tag/ title and h1:
      <title>
       Posts by tag — Sample site
      </title>
    --
       <h1>
        Posts by tag
       </h1>

    blog title and h1:
      <title>
       Blog — Sample site
      </title>
    --
       <h1>
        Blog
       </h1>

    about title and h1:
      <title>
       About — Sample site
      </title>
    --
       <h1>
        About
       </h1>
    ```

## Root cause analysis

1. In the blog section, the make-post-header widget configured in soupault.toml is responsible for generating the h1 elements on the  page:

    ```
    $ grep -A20 widgets.make-post-header soupault.toml
    [widgets.make-post-header]
      widget = "post-header"
      section = "blog/"
      exclude_page = "blog/index.md"

      content_container_selector = "main"

      post_header_template = '''
        <div id="post-header">
          <h1 id="post-title">{{title}}</h1>
          <div><strong>Last update:</strong> <time id="post-date" datetime="{{date}}">{{date}}</time></div>
          {% if tags %}
            <div class="post-tags">
             <span><strong>Tags:</strong> </span>
             {%- for t in tags -%}
               <a href="/blog/tag/{{t}}"><span class="post-tag">{{t}}</span></a>{% if not loop.last %}, {% endif %}
             {%- endfor -%}
             </div>
            {% endif %}
        </div>
    '''
    ```

2. Enable debug mode in soupault.toml

3. Rebuild the site and observe the widget processing order has the set-page-title widget running before
   the make-post-header widget, and hence before the h1 element is inserted into the blog section pages:

    ```
    soupault 2>&1 |grep order
    [DEBUG] Widget processing order: atom set-page-title make-post-header ...
    ```

## Fix details

1. Modify soupault.toml to ensure the set-page-title widget only runs after the make-post-header widget

## Fix verification steps

1. The title for each page now correctly incorporates the contents of the h1 on the page:

    ```
    $ for slug in blog/first-post blog/second-post blog/tag/test blog/tag/post blog/tag/ blog about ; do  echo -e "\n$slug title and h1:" && curl -s "http://127.0.0.1:8000/$slug/" |grep -A2 -e '<h1' -e '<title>' ; done

    blog/first-post title and h1:
      <title>
       My first post — Sample site
      </title>
    --
        <h1 id="post-title">
         My first post
        </h1>

    blog/second-post title and h1:
      <title>
       My second post — Sample site
      </title>
    --
        <h1 id="post-title">
         My second post
        </h1>

    blog/tag/test title and h1:
      <title>
       Posts tagged "test" — Sample site
      </title>
    --
       <h1>
        Posts tagged "test"
       </h1>

    blog/tag/post title and h1:
      <title>
       Posts tagged "post" — Sample site
      </title>
    --
       <h1>
        Posts tagged "post"
       </h1>

    blog/tag/ title and h1:
      <title>
       Posts by tag — Sample site
      </title>
    --
       <h1>
        Posts by tag
       </h1>

    blog title and h1:
      <title>
       Blog — Sample site
      </title>
    --
       <h1>
        Blog
       </h1>

    about title and h1:
      <title>
       About — Sample site
      </title>
    --
       <h1>
        About
       </h1>
    ```
